### PR TITLE
feat: New magic command for parameterized execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ pip uninstall sshkernel
 
 Basic examples of using SSH Kernel.
 
-* [Getting Started](examples/getting-started.ipynb)
-* [Getting Started (in Japanese)](examples/getting-started-ja.ipynb)
+* [Getting Started](https://github.com/NII-cloud-operation/sshkernel/blob/master/examples/getting-started.ipynb)
+* [Getting Started (in Japanese)](https://github.com/NII-cloud-operation/sshkernel/blob/master/examples/getting-started-ja.ipynb)
 
 ## Configuration
 
@@ -84,7 +84,7 @@ See also a tutorial above in detail.
 
 ## Parameterized run
 
-See <examples/parameterized-notebook.ipynb>.
+See [examples/parameterized-notebook](https://github.com/NII-cloud-operation/sshkernel/blob/master/examples/parameterized-notebook.ipynb).
 
 ## Limitations
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ Minimal example:
 
 See also a tutorial above in detail.
 
+## Parameterized run
+
+See <examples/parameterized-notebook.ipynb>.
+
 ## Limitations
 
 * As Jupyter Notebook has limitation to handle `stdin`,

--- a/examples/getting-started-ja.ipynb
+++ b/examples/getting-started-ja.ipynb
@@ -501,6 +501,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "#### %param記法\n",
+    "\n",
+    "`%param {変数名} {変数値}` はノートブック上で使えるパラメータを宣言します。\n",
+    "\n",
+    "詳細は [parameterized-notebook-ja](./parameterized-notebook-ja.ipynb) を参照して下さい。"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### その他\n",
     "\n",
     "実装の仕組み上使えるものの未検証であったり主眼でない機能について触れます。"
@@ -517,9 +528,13 @@
    "source": [
     "#### ! 記法\n",
     "\n",
-    "!で始まるセル内容は、ローカルシェルで実行されます。\n",
+    "<strong><u>非推奨</u></strong>\n",
     "\n",
-    "注：この記法は、IPythonやipykernelの記法に似たものですが、IPythonやipykernelのように行内に書くことはできません"
+    "`!` で始まるセル内容は、ローカルシェルで実行されます。\n",
+    "\n",
+    "* 注\n",
+    "    * この記法は、コマンドが異常終了したとしても正常終了になってしまうため、利用を推奨しません。コマンドの異常終了を検知したい場合には`%login localhost`実行後にコマンドを入力してください\n",
+    "    * この記法は、IPythonやipykernelの記法に似たものですが、IPythonやipykernelのように行内に書くことはできません"
    ]
   },
   {
@@ -667,7 +682,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/examples/parameterized-notebook-ja.ipynb
+++ b/examples/parameterized-notebook-ja.ipynb
@@ -1,0 +1,283 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# ノートブックのパラメタライズ\n",
+    "\n",
+    "SSH Kernelのノートブックで変数を宣言・参照する方法を説明します。<br><br><br>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 変数の宣言：`%param`\n",
+    "\n",
+    "`%param <変数名> <変数値>` 記法は、新しい変数を宣言します。\n",
+    "\n",
+    "* 注\n",
+    "    * 〈変数名〉に使うことのできる文字は次の通り： A-Z a-z 0-9 _\n",
+    "    * 〈変数値〉に使うことのできる文字は次の通り： A-Z a-z 0-9 - % , . / : = _ @ SPACE"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 例"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%param HOST_A 127.0.0.1\n",
+    "%param HOST_B test.example.com"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "==> `HOST_A`, `HOST_B`の変数が宣言され、次に示す方法で参照できます。\n",
+    "\n",
+    "<br><br><br>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## `%login`での変数展開\n",
+    "\n",
+    "上で宣言された変数は、`%login` 記法のなかで `{name}` と書くことで展開できます。"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 例"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[ssh] Login to {HOST_A}...\n",
+      "[ssh] host=127.0.0.1 hostname=127.0.0.1 other_conf={}\n",
+      "[ssh] Successfully logged in.\n"
+     ]
+    }
+   ],
+   "source": [
+    "%login {HOST_A}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "==> `{HOST_A}` は `127.0.0.1` に置き換わります\n",
+    "\n",
+    "<br><br><br>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## リモート環境で環境変数として参照する\n",
+    "\n",
+    "上で宣言された変数は、リモート環境で環境変数として参照することができます。\n",
+    "\n",
+    "* 注\n",
+    "    * 宣言された変数は、環境変数のデフォルト値として、リモート環境へのログイン時に注入されます\n",
+    "        * ログイン後に環境変数を再代入した場合（つまりコマンド`export HOST_B=xxx`と実行した場合）には、その変数はそのリモート環境でのみ上書きされます"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 例"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[ssh] Closing existing connection.\n",
+      "[ssh] Login to {HOST_B}...\n",
+      "[ssh] host=test.example.com hostname=localhost other_conf={'port': 22}\n",
+      "[ssh] Successfully logged in.\n"
+     ]
+    }
+   ],
+   "source": [
+    "%login {HOST_B}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[ssh] host = test.example.com, cwd = /home/masaru\n",
+      "HOST_A=127.0.0.1\n",
+      "HOST_B=test.example.com\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "env |sort | grep HOST_"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[ssh] host = test.example.com, cwd = /home/masaru\n",
+      "HOST_A is 127.0.0.1\n",
+      "HOST_B is test.example.com\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "echo HOST_A is $HOST_A\n",
+    "echo HOST_B is $HOST_B"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[ssh] Successfully logged out.\n"
+     ]
+    }
+   ],
+   "source": [
+    "%logout"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Papermillとの統合\n",
+    "\n",
+    "[Papermill](https://github.com/nteract/papermill)に次のパッチを当てて用いると、SSH Kernel形式のノートブックをコマンドラインからパラメタライズ実行できます。\n",
+    "\n",
+    "* `%param` を含むセルをノートブックに挿入するためのパッチ：\n",
+    "\n",
+    "```diff\n",
+    "--- papermill/translators.py.orig       2019-05-10 18:44:49.592111720 +0900\n",
+    "+++ papermill/translators.py    2019-04-25 17:32:40.204800528 +0900\n",
+    "@@ -200,12 +200,31 @@\n",
+    "         return '# {}'.format(cmt_str).strip()\n",
+    "\n",
+    "\n",
+    "+class SSHTranslator(Translator):\n",
+    "+    @classmethod\n",
+    "+    def translate_str(cls, val):\n",
+    "+        \"\"\"Default behavior for translation\"\"\"\n",
+    "+        return cls.translate_raw_str(val)\n",
+    "+\n",
+    "+    @classmethod\n",
+    "+    def assign(cls, name, str_val):\n",
+    "+        return '%param {} {}'.format(name, str_val)\n",
+    "+\n",
+    "+    @classmethod\n",
+    "+    def codify(cls, parameters):\n",
+    "+        content = ''\n",
+    "+        for name, val in parameters.items():\n",
+    "+            content += '{}\\n'.format(cls.assign(name, cls.translate(val)))\n",
+    "+        return content\n",
+    "+\n",
+    "+\n",
+    " # Instantiate a PapermillIO instance and register Handlers.\n",
+    " papermill_translators = PapermillTranslators()\n",
+    " papermill_translators.register(\"python\", PythonTranslator)\n",
+    " papermill_translators.register(\"R\", RTranslator)\n",
+    " papermill_translators.register(\"scala\", ScalaTranslator)\n",
+    " papermill_translators.register(\"julia\", JuliaTranslator)\n",
+    "+papermill_translators.register(\"ssh\", SSHTranslator)\n",
+    "\n",
+    "\n",
+    " def translate_parameters(kernel_name, parameters):\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 実行例\n",
+    "\n",
+    "Papermillに上記パッチを当て、次のコマンドを実行します。\n",
+    "\n",
+    "```shell\n",
+    "papermill -p HOST_A 20.20.20.20 input.ipynb output.ipynb\n",
+    "```"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "SSH",
+   "language": "bash",
+   "name": "ssh"
+  },
+  "language_info": {
+   "codemirror_mode": "shell",
+   "file_extension": ".sh",
+   "mimetype": "text/x-sh",
+   "name": "ssh"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/examples/parameterized-notebook.ipynb
+++ b/examples/parameterized-notebook.ipynb
@@ -1,0 +1,265 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Parameterized notebook\n",
+    "\n",
+    "This page describes how to declare and use variables inside ssh kernel notebooks.<br><br><br>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Declare variables with `%param` magic\n",
+    "\n",
+    "`%param <variable> <value>` magic declare a new variable.\n",
+    "\n",
+    "* Note:\n",
+    "    * Allowed characters in `variable`: A-Z a-z 0-9 _\n",
+    "    * Allowed characters in `value`: A-Z a-z 0-9 - % , . / : = _ @ SPACE"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Example"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%param HOST_A 127.0.0.1\n",
+    "%param HOST_B test.example.com"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "==> Declared two variables `HOST_A`, `HOST_B` . You can use these variables as follows.\n",
+    "\n",
+    "<br><br><br>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Refer variables in `%login` magic\n",
+    "\n",
+    "Variables declared above are interpolated with `{name}` syntax in `%login` magic."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Example"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[ssh] Login to {HOST_A}...\n",
+      "[ssh] host=127.0.0.1 hostname=127.0.0.1 other_conf={}\n",
+      "[ssh] Successfully logged in.\n"
+     ]
+    }
+   ],
+   "source": [
+    "%login {HOST_A}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "==> `{HOST_A}` is replaced to `127.0.0.1`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[ssh] host = 127.0.0.1, cwd = /home/masaru\n",
+      "Hey, this is HOST_A\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "echo Hey, this is HOST_A"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[ssh] Successfully logged out.\n"
+     ]
+    }
+   ],
+   "source": [
+    "%logout"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<br><br><br>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Refer variable as remote environment variables\n",
+    "\n",
+    "Variables declared above are read by environment variables.\n",
+    "\n",
+    "* Note:\n",
+    "    * Declared variables are injected as default environment variables at login.\n",
+    "        * You can re-assign environment variables in remote context (i.e. execute `export HOST_B=xxx` or `HOST_B=xxx`)\n",
+    "        * However, the new value does not propagate to the \"local\" or other context.\n",
+    "        * That is, you cannot share environment variables between remote hosts."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Example"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[ssh] Closing existing connection.\n",
+      "[ssh] Login to {HOST_B}...\n",
+      "[ssh] host=test.example.com hostname=localhost other_conf={'port': 22}\n",
+      "[ssh] Successfully logged in.\n"
+     ]
+    }
+   ],
+   "source": [
+    "%login {HOST_B}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[ssh] host = test.example.com, cwd = /home/masaru\n",
+      "\u001b[01;31m\u001b[KHOST_A\u001b[m\u001b[K=127.0.0.1\n",
+      "\u001b[01;31m\u001b[KHOST_B\u001b[m\u001b[K=test.example.com\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "printenv |sort | grep --color=always \"HOST_.\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[ssh] host = test.example.com, cwd = /home/masaru\n",
+      "HOST_A is 127.0.0.1\n",
+      "HOST_B is test.example.com\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "echo HOST_A is $HOST_A\n",
+    "echo HOST_B is $HOST_B"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[ssh] Successfully logged out.\n"
+     ]
+    }
+   ],
+   "source": [
+    "%logout"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "SSH",
+   "language": "bash",
+   "name": "ssh"
+  },
+  "language_info": {
+   "codemirror_mode": "shell",
+   "file_extension": ".sh",
+   "mimetype": "text/x-sh",
+   "name": "ssh"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/misc/watch-test-ptw
+++ b/misc/watch-test-ptw
@@ -1,1 +1,1 @@
-ptw tests/unit -- --disable-pytest-warnings
+ptw sshkernel tests/unit -- --disable-pytest-warnings

--- a/sshkernel/exception.py
+++ b/sshkernel/exception.py
@@ -1,2 +1,6 @@
-class SSHKernelNotConnectedException(Exception):
+class Error(Exception):
+    """Base class for exceptions in this module."""
+    pass
+
+class SSHKernelNotConnectedException(Error):
     pass

--- a/sshkernel/kernel.py
+++ b/sshkernel/kernel.py
@@ -107,7 +107,7 @@ class SSHKernel(MetaKernel):
 
         self.del_ssh_wrapper()
 
-        self.sshwrapper = SSHWrapperPlumbum()
+        self.sshwrapper = SSHWrapperPlumbum(self.get_params())
 
     def del_ssh_wrapper(self):
         '''

--- a/sshkernel/kernel.py
+++ b/sshkernel/kernel.py
@@ -81,6 +81,22 @@ class SSHKernel(MetaKernel):
         self.log.setLevel(INFO)
         self.redirect_to_log = True
         self._sshwrapper = None
+        self._parameters = dict()
+
+    def set_param(self, key, value):
+        '''
+        Set sshkernel parameter for hostname and remote envvars.
+        '''
+
+        self._parameters[key] = value
+
+    def get_params(self):
+        '''
+        Get sshkernel parameters dict.
+        '''
+
+        return self._parameters
+
 
     def new_ssh_wrapper(self):
         '''
@@ -198,6 +214,7 @@ class SSHKernel(MetaKernel):
         # self.Print('[INFO] Restart sshkernel ...')
 
         self.del_ssh_wrapper()
+        self._parameters = dict()
 
     def assert_connected(self):
         '''

--- a/sshkernel/magics.py
+++ b/sshkernel/magics.py
@@ -112,7 +112,7 @@ class SSHKernelMagics(Magic):
         '''
         m = re.match(self.blacklist, str(val_str))
         if m:
-            msg = "{val} contains invalid character {matched}. Valid characters are A-Z a-z 0-9 - % , . / : = _".format(
+            msg = "{val} contains invalid character {matched}. Valid characters are A-Z a-z 0-9 - % , . / : = _ @".format(
                 val=repr(val_str), matched=repr(m.group(1))
             )
             raise ValueError(msg)

--- a/sshkernel/magics.py
+++ b/sshkernel/magics.py
@@ -118,8 +118,10 @@ class SSHKernelMagics(Magic):
             raise ValueError(msg)
 
     def post_process(self, retval):
-        return self.retval
-
+        try:
+            return self.retval
+        except AttributeError:
+            return retval
 
 def register_magics(kernel):
     kernel.register_magics(SSHKernelMagics)

--- a/sshkernel/magics.py
+++ b/sshkernel/magics.py
@@ -8,7 +8,7 @@ from metakernel import Magic
 
 class SSHKernelMagics(Magic):
 
-    blacklist = re.compile(r'.*([^- %,\./:=_a-zA-Z\d])')
+    blacklist = re.compile(r'.*([^- %,\./:=_a-zA-Z\d@])')
 
     def line_login(self, host):
         """

--- a/sshkernel/ssh_wrapper.py
+++ b/sshkernel/ssh_wrapper.py
@@ -1,6 +1,13 @@
-from abc import ABC, abstractmethod
+from abc import ABC, abstractmethod 
 
 class SSHWrapper(ABC):
+    @abstractmethod
+    def __init__(self, envdelta):
+        '''
+        Args:
+            envdelta (dict) envdelta is injected into remote environment variables
+        '''
+
     @abstractmethod
     def exec_command(self, cmd, print_function):
         '''

--- a/sshkernel/ssh_wrapper_plumbum.py
+++ b/sshkernel/ssh_wrapper_plumbum.py
@@ -1,3 +1,4 @@
+from types import MappingProxyType
 import os
 import time
 import yaml
@@ -14,7 +15,8 @@ class SSHWrapperPlumbum(SSHWrapper):
     A plumbum remote machine wrapper
     '''
 
-    def __init__(self):
+    def __init__(self, envdelta_init=dict()):
+        self.envdelta_init = MappingProxyType(dict((k, shquote(v)) for k,v in envdelta_init.items()))
         self._remote = None
         self._connected = False
         self._host = ''
@@ -86,7 +88,7 @@ echo {marker}env: $(cat -v <(env -0))
 
         remote = self._build_remote(host)
 
-        envdelta = {'PAGER': 'cat'}
+        envdelta = {**self.envdelta_init, 'PAGER': 'cat'}
         remote.env.update(envdelta)
 
         self._remote = remote

--- a/tests/integration/parameterized-centos7.ipynb
+++ b/tests/integration/parameterized-centos7.ipynb
@@ -1,0 +1,83 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%param TARGET_HOST centos7"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2018-12-13T11:38:08.836695Z",
+     "start_time": "2018-12-13T11:38:08.619631Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "%login {TARGET_HOST}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2018-12-13T11:38:32.762303Z",
+     "start_time": "2018-12-13T11:38:32.668820Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "id"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2018-12-13T11:38:36.369487Z",
+     "start_time": "2018-12-13T11:38:36.310821Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "%logout"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "SSH",
+   "language": "bash",
+   "name": "ssh"
+  },
+  "language_info": {
+   "codemirror_mode": "shell",
+   "file_extension": ".sh",
+   "mimetype": "text/x-sh",
+   "name": "ssh"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tests/integration/parameterized-ubuntu-18.ipynb
+++ b/tests/integration/parameterized-ubuntu-18.ipynb
@@ -1,0 +1,83 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%param TARGET_HOST ubuntu18"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2018-12-13T11:38:08.836695Z",
+     "start_time": "2018-12-13T11:38:08.619631Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "%login {TARGET_HOST}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2018-12-13T11:38:32.762303Z",
+     "start_time": "2018-12-13T11:38:32.668820Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "id"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2018-12-13T11:38:36.369487Z",
+     "start_time": "2018-12-13T11:38:36.310821Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "%logout"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "SSH",
+   "language": "bash",
+   "name": "ssh"
+  },
+  "language_info": {
+   "codemirror_mode": "shell",
+   "file_extension": ".sh",
+   "mimetype": "text/x-sh",
+   "name": "ssh"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tests/unit/test_kernel.py
+++ b/tests/unit/test_kernel.py
@@ -227,3 +227,8 @@ class SSHKernelTest(unittest.TestCase):
         self.instance.new_ssh_wrapper()
 
         wrapper_double.close.assert_called_once()
+
+    def test_params(self):
+        self.assertEqual(dict(), self.instance.get_params())
+        self.instance.set_param('KEY1', 'VALUE1')
+        self.assertEqual({'KEY1': 'VALUE1'}, self.instance.get_params())

--- a/tests/unit/test_magics.py
+++ b/tests/unit/test_magics.py
@@ -53,3 +53,23 @@ class MagicTest(unittest.TestCase):
     def test_expand_parameters_with_unclosed_string(self):
         ret = self.instance.expand_parameters('{YO', {})
         self.assertEqual(ret, '{YO')
+
+    def test_validate_value_string(self):
+        func = self.instance.validate_value_string
+
+        ok_cases = [
+            'abc 123%',
+        ]
+        ng_cases = [
+            'ABC ###',
+            'ABC"',
+            'ABC()',
+            'ABC${}',
+        ]
+
+        for ok in ok_cases:
+            self.assertIsNone(func(ok))
+
+        for ng in ng_cases:
+            with self.assertRaises(ValueError):
+                func(ng)

--- a/tests/unit/test_magics.py
+++ b/tests/unit/test_magics.py
@@ -58,7 +58,7 @@ class MagicTest(unittest.TestCase):
         func = self.instance.validate_value_string
 
         ok_cases = [
-            'abc 123%',
+            'abc 123%@-',
         ]
         ng_cases = [
             'ABC ###',

--- a/tests/unit/test_magics.py
+++ b/tests/unit/test_magics.py
@@ -38,3 +38,18 @@ class MagicTest(unittest.TestCase):
 
         self.assertIsNone(noreturn)
         self.assertIsNone(self.instance.retval)
+
+    def test_expand_parameters(self):
+        params = dict(A="1", B="3")
+        s = '{A}2{B}'
+
+        ret = self.instance.expand_parameters(s, params)
+        self.assertEqual(ret, "123")
+
+    def test_expand_parameters_raise(self):
+        with self.assertRaises(KeyError):
+            self.instance.expand_parameters('{NOTFOUND}', {})
+
+    def test_expand_parameters_with_unclosed_string(self):
+        ret = self.instance.expand_parameters('{YO', {})
+        self.assertEqual(ret, '{YO')


### PR DESCRIPTION
Introduce `%param <variable> <value>` magic to declare and refer parameters in notebooks.

See "examples/parameterized-notebook.ipynb" for details.

