### PR TITLE
Override SSHKernel.Print()

### DIFF
--- a/sshkernel/kernel.py
+++ b/sshkernel/kernel.py
@@ -226,3 +226,6 @@ class SSHKernel(MetaKernel):
         elif not self.sshwrapper.isconnected():
             self.Error('[ssh] Not connected.')
             raise SSHKernelNotConnectedException
+
+    def Print(self, message):
+        super().Write(str(message) + "\n")


### PR DESCRIPTION
To avoid using buggy metakernel.Print (metakernel==0.24.0), override it.