### PR TITLE
Partial support for ProxyCommand

### DIFF
--- a/sshkernel/kernel.py
+++ b/sshkernel/kernel.py
@@ -91,8 +91,8 @@ class SSHKernel(MetaKernel):
         self.do_logout()
 
         wrapper = self.__sshwrapper_class(self.get_params())
+        wrapper.connect(host)
         self.sshwrapper = wrapper
-        self.sshwrapper.connect(host)
 
     def do_logout(self):
         """Close the connection."""

--- a/sshkernel/ssh_wrapper_plumbum.py
+++ b/sshkernel/ssh_wrapper_plumbum.py
@@ -18,7 +18,7 @@ class SSHWrapperPlumbum(SSHWrapper):
     def __init__(self, envdelta_init=dict()):
         self.envdelta_init = envdelta_init
         self._remote = None
-        self._connected = False
+        self.__connected = False
         self._host = ""
         self.interrupt_function = lambda: None
 
@@ -59,17 +59,11 @@ class SSHWrapperPlumbum(SSHWrapper):
         remote.env.update(envdelta)
 
         self._remote = remote
-        self._connected = True
+        self.__connected = True
         self._host = host
 
-    def _forward_local_agent(self, paramiko_client):
-        # SSH Agent Forwarding in Paramiko
-        # http://docs.paramiko.org/en/2.4/api/agent.html
-        sess = paramiko_client.get_transport().open_session()
-        paramiko.agent.AgentRequestHandler(sess)
-
     def _build_remote(self, host):
-        (hostname, plumbum_kwargs, forward_agent) = self._load_ssh_config_for_plumbum(
+        (hostname, plumbum_kwargs, forward_agent) = load_ssh_config_for_plumbum(
             "~/.ssh/config", host
         )
 
@@ -83,12 +77,12 @@ class SSHWrapperPlumbum(SSHWrapper):
 
         if forward_agent == "yes":
             print("[ssh] forwarding local agent")
-            self._forward_local_agent(remote._client)
+            enable_agent_forwarding(remote._client)
 
         return remote
 
     def close(self):
-        self._connected = False
+        self.__connected = False
 
         if self._remote:
             self._remote.close()
@@ -97,7 +91,7 @@ class SSHWrapperPlumbum(SSHWrapper):
         self.interrupt_function()
 
     def isconnected(self):
-        return self._connected
+        return self.__connected
 
     # private methods
     def _update_interrupt_function(self, proc):
@@ -144,36 +138,6 @@ class SSHWrapperPlumbum(SSHWrapper):
         }
 
         self._remote.env.update(parsed_newenv)
-
-    def _load_ssh_config_for_plumbum(self, filename, host):
-        """Parse and postprocess ssh_config
-        """
-
-        conf = paramiko.config.SSHConfig()
-        expanded_path = os.path.expanduser(filename)
-
-        if os.path.exists(expanded_path):
-            with open(expanded_path) as ssh_config:
-                conf.parse(ssh_config)
-
-        lookup = conf.lookup(host)
-
-        plumbum_kwargs = dict(user=None, port=None, keyfile=None)
-
-        if "hostname" in lookup:
-            plumbum_hostname = lookup.pop("hostname")
-        else:
-            plumbum_hostname = host
-
-        if "port" in lookup:
-            plumbum_kwargs["port"] = int(lookup["port"])
-
-        plumbum_kwargs["user"] = lookup.get("user")
-        plumbum_kwargs["keyfile"] = lookup.get("identityfile")
-
-        forward_agent = lookup.get("forwardagent")
-
-        return (plumbum_hostname, plumbum_kwargs, forward_agent)
 
 
 def append_footer(cmd, marker):
@@ -249,3 +213,41 @@ def process_output(tuple_iterator, marker, print_function):
             print_function(line)
 
     return env_out
+
+
+def enable_agent_forwarding(paramiko_sshclient):
+    # SSH Agent Forwarding in Paramiko
+    # http://docs.paramiko.org/en/stable/api/agent.html#paramiko.agent.AgentRequestHandler
+    sess = paramiko_sshclient.get_transport().open_session()
+    paramiko.agent.AgentRequestHandler(sess)
+
+
+def load_ssh_config_for_plumbum(filename, host):
+    """Parse and postprocess ssh_config
+    """
+
+    conf = paramiko.config.SSHConfig()
+    expanded_path = os.path.expanduser(filename)
+
+    if os.path.exists(expanded_path):
+        with open(expanded_path) as ssh_config:
+            conf.parse(ssh_config)
+
+    lookup = conf.lookup(host)
+
+    plumbum_kwargs = dict(user=None, port=None, keyfile=None)
+
+    if "hostname" in lookup:
+        plumbum_hostname = lookup.pop("hostname")
+    else:
+        plumbum_hostname = host
+
+    if "port" in lookup:
+        plumbum_kwargs["port"] = int(lookup["port"])
+
+    plumbum_kwargs["user"] = lookup.get("user")
+    plumbum_kwargs["keyfile"] = lookup.get("identityfile")
+
+    forward_agent = lookup.get("forwardagent")
+
+    return (plumbum_hostname, plumbum_kwargs, forward_agent)

--- a/sshkernel/ssh_wrapper_plumbum.py
+++ b/sshkernel/ssh_wrapper_plumbum.py
@@ -1,9 +1,11 @@
 import os
 import time
-import yaml
 
 import paramiko
+
 from plumbum.machines.paramiko_machine import ParamikoMachine
+
+import yaml
 
 from .ssh_wrapper import SSHWrapper
 

--- a/tests/integration/setup.py
+++ b/tests/integration/setup.py
@@ -3,71 +3,77 @@ import subprocess
 
 
 def _run(cmd):
-    print('run: {}'.format(cmd))
+    print("run: {}".format(cmd))
 
-    return subprocess.check_output(cmd, shell=True, encoding='utf-8', universal_newlines=True)
+    return subprocess.check_output(
+        cmd, shell=True, encoding="utf-8", universal_newlines=True
+    )
 
 
 def make_ssh_config(host, keyfile):
 
-    _run('chmod 600 {keyfile}'.format(keyfile=keyfile))
-    _run('mkdir -p ~/.ssh; chmod 700 ~/.ssh')
-    target = os.path.expanduser('~/.ssh/config')
-    config = '''
+    _run("chmod 600 {keyfile}".format(keyfile=keyfile))
+    _run("mkdir -p ~/.ssh; chmod 700 ~/.ssh")
+    target = os.path.expanduser("~/.ssh/config")
+    config = """
 Host {host}
     Hostname {hostname}
     User root
     Port 22
     IdentityFile {keyfile}
-'''.format(host=host, hostname=host, keyfile=keyfile)
+""".format(
+        host=host, hostname=host, keyfile=keyfile
+    )
 
-    with open(target, 'a') as f:
+    with open(target, "a") as f:
         f.write(config)
 
-    print('wrote {target}'.format(target=target))
+    print("wrote {target}".format(target=target))
 
 
 def update_known_hosts(host):
-    cmd = 'ssh-keyscan -H {host} >> ~/.ssh/known_hosts'.format(host=host)
+    cmd = "ssh-keyscan -H {host} >> ~/.ssh/known_hosts".format(host=host)
     buf = _run(cmd)
     print(buf)
 
 
 def install_sshpass():
-    cmd = 'apt-get update && apt-get install -yq sshpass'
+    cmd = "apt-get update && apt-get install -yq sshpass"
     print(_run(cmd))
 
 
 def ssh_copy_id(host, key, password):
-    cmd = 'sshpass -p {password} ssh-copy-id -i {key} {host}'.format(key=key, host=host, password=password)
+    cmd = "sshpass -p {password} ssh-copy-id -i {key} {host}".format(
+        key=key, host=host, password=password
+    )
     print(_run(cmd))
 
 
 def check_login(host):
-    print(_run('cat ~/.ssh/config'))
+    print(_run("cat ~/.ssh/config"))
 
-    cmd = 'ssh {host} echo ok'.format(host=host)
+    cmd = "ssh {host} echo ok".format(host=host)
     buf = _run(cmd)
 
-    assert 'ok' in buf
+    assert "ok" in buf
 
 
 def install_sshkernel():
-    cmd = 'python -msshkernel install'
+    cmd = "python -msshkernel install"
     print(_run(cmd))
 
 
 def main():
     hosts = [
-        ('ubuntu18', 'root', 'root'),
-        ('centos7', 'root', 'indig0!'),
+        ("ubuntu18", "root", "root"),
+        ("centos7", "root", "indig0!"),
     ]
 
     for (host, _user, password) in hosts:
         base = os.path.dirname(__file__)
-        keyfile = os.path.abspath('{base}/id_rsa'.format(base=base))
+        keyfile = os.path.abspath("{base}/id_rsa".format(base=base))
 
-        if host.startswith('ubuntu'):
+        if host.startswith("ubuntu"):
             install_sshpass()
 
         make_ssh_config(host, keyfile)
@@ -77,5 +83,6 @@ def main():
         check_login(host)
 
     install_sshkernel()
+
 
 main()

--- a/tests/integration/test_sshd_integration.py
+++ b/tests/integration/test_sshd_integration.py
@@ -4,8 +4,23 @@ import unittest
 
 import papermill as pm
 
+from sshkernel.kernel import SSHKernel
+
 
 class SSHDIntegrationTests(unittest.TestCase):
+    def test_proxycommand(self):
+        """
+        # Expect the config below
+        Host localhost
+            User root
+            Port 22
+            IdentityFile {keyfile}
+            ProxyCommand ssh -W %h:%p {bastion}
+        """
+        kernel = SSHKernel()
+        kernel.do_login("localhost")
+        kernel.assert_connected()
+
     def list_notebooks(self):
         here = os.path.dirname(__file__)
         nbs = glob.glob("{}/*.ipynb".format(here))

--- a/tests/integration/test_sshd_integration.py
+++ b/tests/integration/test_sshd_integration.py
@@ -6,10 +6,9 @@ import papermill as pm
 
 
 class SSHDIntegrationTests(unittest.TestCase):
-
     def list_notebooks(self):
         here = os.path.dirname(__file__)
-        nbs = glob.glob('{}/*.ipynb'.format(here))
+        nbs = glob.glob("{}/*.ipynb".format(here))
 
         return nbs
 
@@ -18,14 +17,14 @@ class SSHDIntegrationTests(unittest.TestCase):
         nbs = self.list_notebooks()
 
         here = os.path.dirname(__file__)
-        out_dir = '{}/out'.format(here)
+        out_dir = "{}/out".format(here)
         if not os.path.exists(out_dir):
             os.mkdir(out_dir)
 
         for nb_input in nbs:
             basename = os.path.basename(nb_input)
 
-            nb_output = '{}/{}'.format(out_dir, basename)
+            nb_output = "{}/{}".format(out_dir, basename)
 
             try:
                 pm.execute_notebook(nb_input, nb_output)

--- a/tests/unit/test_ssh_wrapper_plumbum.py
+++ b/tests/unit/test_ssh_wrapper_plumbum.py
@@ -9,6 +9,7 @@ from plumbum.machines.paramiko_machine import ParamikoMachine
 
 from sshkernel.ssh_wrapper_plumbum import SSHWrapperPlumbum
 from sshkernel.ssh_wrapper_plumbum import append_footer
+from sshkernel.ssh_wrapper_plumbum import load_ssh_config_for_plumbum
 from sshkernel.ssh_wrapper_plumbum import merge_stdout_stderr
 from sshkernel.ssh_wrapper_plumbum import process_output
 
@@ -96,7 +97,7 @@ class SSHWrapperPlumbumTest(unittest.TestCase):
 
             f.seek(0)
 
-            (hostname, lookup, forward) = self.instance._load_ssh_config_for_plumbum(
+            (hostname, lookup, forward) = load_ssh_config_for_plumbum(
                 f.name, "test"
             )
 
@@ -116,7 +117,7 @@ class SSHWrapperPlumbumTest(unittest.TestCase):
 
             f.seek(0)
 
-            (hostname, lookup, _) = self.instance._load_ssh_config_for_plumbum(
+            (hostname, lookup, _) = load_ssh_config_for_plumbum(
                 f.name, "test2"
             )
 
@@ -141,7 +142,7 @@ class SSHWrapperPlumbumTest(unittest.TestCase):
 
             f.seek(0)
 
-            (hostname, lookup, forward) = self.instance._load_ssh_config_for_plumbum(
+            (hostname, lookup, forward) = load_ssh_config_for_plumbum(
                 f.name, "test3"
             )
 

--- a/tests/unit/test_ssh_wrapper_plumbum.py
+++ b/tests/unit/test_ssh_wrapper_plumbum.py
@@ -1,18 +1,12 @@
-from textwrap import dedent
-from unittest.mock import Mock
-from unittest.mock import PropertyMock
-from unittest.mock import patch
 import io
 import socket
 import unittest
+from textwrap import dedent
+from unittest.mock import Mock
+from unittest.mock import patch
 
-import paramiko
-import plumbum
 from plumbum.machines.paramiko_machine import ParamikoMachine
 
-from sshkernel import ExceptionWrapper
-from sshkernel import SSHException
-from sshkernel.ssh_wrapper import SSHWrapper
 from sshkernel.ssh_wrapper_plumbum import SSHWrapperPlumbum
 from sshkernel.ssh_wrapper_plumbum import append_footer
 from sshkernel.ssh_wrapper_plumbum import merge_stdout_stderr
@@ -21,9 +15,6 @@ from sshkernel.ssh_wrapper_plumbum import process_output
 
 class SSHWrapperPlumbumTest(unittest.TestCase):
     def setUp(self):
-        closed = True
-        connected = False
-
         subscriptable = Mock()
         subscriptable.popen = Mock(return_value=subscriptable)
         subscriptable.__getitem__ = Mock(return_value=subscriptable)

--- a/tests/unit/test_ssh_wrapper_plumbum.py
+++ b/tests/unit/test_ssh_wrapper_plumbum.py
@@ -18,8 +18,8 @@ from sshkernel.ssh_wrapper_plumbum import append_footer
 from sshkernel.ssh_wrapper_plumbum import merge_stdout_stderr
 from sshkernel.ssh_wrapper_plumbum import process_output
 
-class SSHWrapperPlumbumTest(unittest.TestCase):
 
+class SSHWrapperPlumbumTest(unittest.TestCase):
     def setUp(self):
         closed = True
         connected = False
@@ -27,7 +27,9 @@ class SSHWrapperPlumbumTest(unittest.TestCase):
         subscriptable = Mock()
         subscriptable.popen = Mock(return_value=subscriptable)
         subscriptable.__getitem__ = Mock(return_value=subscriptable)
-        subscriptable.iter_lines = Mock(return_value=([('output', None), (None, 'err')]))
+        subscriptable.iter_lines = Mock(
+            return_value=([("output", None), (None, "err")])
+        )
 
         remote_double = Mock(spec=ParamikoMachine)
         remote_double.__getitem__ = Mock(return_value=subscriptable)
@@ -39,7 +41,7 @@ class SSHWrapperPlumbumTest(unittest.TestCase):
 
     def test_connect_should_raise_socket_error(self):
         # FIXME: fix setUp() to pass the line below
-        #self.assertIsNone(self.instance._remote)
+        # self.assertIsNone(self.instance._remote)
         self.assertFalse(self.instance._connected)
 
         with self.assertRaises(socket.gaierror):
@@ -48,10 +50,10 @@ class SSHWrapperPlumbumTest(unittest.TestCase):
     def test_connect_updates_attributes(self):
         remote_double = Mock()
         self.instance._build_remote = Mock(return_value=remote_double)
-        dummy = 'dummy'
-        #self.assertIsNone(self.instance._remote)
+        dummy = "dummy"
+        # self.assertIsNone(self.instance._remote)
         self.assertFalse(self.instance._connected)
-        self.assertEqual(self.instance._host, '')
+        self.assertEqual(self.instance._host, "")
 
         self.instance.connect(dummy)
 
@@ -59,23 +61,23 @@ class SSHWrapperPlumbumTest(unittest.TestCase):
         self.assertEqual(self.instance._host, dummy)
         remote_double.env.update.assert_called()
 
-    @unittest.skip('fix setUp')
+    @unittest.skip("fix setUp")
     def test_exec_command_returns_error_at_first(self):
         print_mock = Mock()
         with self.assertRaises(socket.gaierror):
-            self.instance.exec_command('yo', lambda line: None)
+            self.instance.exec_command("yo", lambda line: None)
 
     @unittest.skip
     def test_exec_command_returns_stream(self):
-        self.instance.connect('myserver')
+        self.instance.connect("myserver")
         print_mock = Mock()
 
-        ret = self.instance.exec_command('yo', print_mock)
+        ret = self.instance.exec_command("yo", print_mock)
 
     def test_exec_command_return_exit_code(self):
         print_mock = Mock()
 
-        code = self.instance.exec_command('ls', print_mock)
+        code = self.instance.exec_command("ls", print_mock)
 
         self.assertIsInstance(code, int)
 
@@ -88,37 +90,52 @@ class SSHWrapperPlumbumTest(unittest.TestCase):
 
     def test_load_ssh_config_for_plumbum(self):
         import tempfile
-        with tempfile.NamedTemporaryFile('w') as f:
-            f.write(dedent("""
+
+        with tempfile.NamedTemporaryFile("w") as f:
+            f.write(
+                dedent(
+                    """
             Host test
                 HostName 127.0.0.10
                 User testuser
                 IdentityFile ~/.ssh/id_rsa_test
-            """))
+            """
+                )
+            )
 
             f.seek(0)
 
-            (hostname, lookup, forward) = self.instance._load_ssh_config_for_plumbum(f.name, "test")
+            (hostname, lookup, forward) = self.instance._load_ssh_config_for_plumbum(
+                f.name, "test"
+            )
 
             self.assertIsInstance(lookup, dict)
             self.assertEqual(hostname, "127.0.0.10")
             self.assertIsNone(forward)
 
-        with tempfile.NamedTemporaryFile('w') as f:
-            f.write(dedent("""
+        with tempfile.NamedTemporaryFile("w") as f:
+            f.write(
+                dedent(
+                    """
             Host test2
                 IdentityFile ~/.ssh/id_rsa_test
-            """))
+            """
+                )
+            )
 
             f.seek(0)
 
-            (hostname, lookup, _) = self.instance._load_ssh_config_for_plumbum(f.name, "test2")
+            (hostname, lookup, _) = self.instance._load_ssh_config_for_plumbum(
+                f.name, "test2"
+            )
 
             self.assertIsInstance(lookup, dict)
             self.assertEqual(hostname, "test2")
 
-        with tempfile.NamedTemporaryFile('w') as f:
-            f.write(dedent("""
+        with tempfile.NamedTemporaryFile("w") as f:
+            f.write(
+                dedent(
+                    """
             Host test3
                 User admin
                 Port 2222
@@ -127,57 +144,63 @@ class SSHWrapperPlumbumTest(unittest.TestCase):
 
             Host *
                 ForwardAgent yes
-            """))
+            """
+                )
+            )
 
             f.seek(0)
 
-            (hostname, lookup, forward) = self.instance._load_ssh_config_for_plumbum(f.name, "test3")
-
-            self.assertEqual(
-                set(lookup.keys()),
-                set(['user', 'port', 'keyfile'])
+            (hostname, lookup, forward) = self.instance._load_ssh_config_for_plumbum(
+                f.name, "test3"
             )
 
-            self.assertEqual(forward, 'yes')
+            self.assertEqual(set(lookup.keys()), set(["user", "port", "keyfile"]))
+
+            self.assertEqual(forward, "yes")
 
     def test_append_footer(self):
-        cmd = '''
+        cmd = """
 ls
 ls
 yo
-'''
-        marker = 'THISISMARKER'
+"""
+        marker = "THISISMARKER"
 
         full_command = append_footer(cmd, marker)
 
         self.assertIsInstance(full_command, str)
         self.assertEqual(full_command.count(marker), 6)
 
-    @unittest.skip('Fail to patch plumbum')
-    @patch('sshkernel.ssh_wrapper_plumbum.SSHWrapperPlumbum.get_cwd', return_value='/tmp')
-    @patch('plumbum.machines.paramiko_machine.ParamikoMachine.cwd.getpath._path', return_value='/home')
+    @unittest.skip("Fail to patch plumbum")
+    @patch(
+        "sshkernel.ssh_wrapper_plumbum.SSHWrapperPlumbum.get_cwd", return_value="/tmp"
+    )
+    @patch(
+        "plumbum.machines.paramiko_machine.ParamikoMachine.cwd.getpath._path",
+        return_value="/home",
+    )
     def test_update_workdir(self, mock1, mock2):
-        mock = Mock()#return_value='/')
+        mock = Mock()  # return_value='/')
         self.instance.get_cwd = mock
         self.instance._remote = mock
-        newdir = '/some/where'
+        newdir = "/some/where"
 
         self.instance.update_workdir(newdir)
 
         mock.assert_called_once()
 
-    @unittest.skip('Fail to patch the instance created in setUp()')
+    @unittest.skip("Fail to patch the instance created in setUp()")
     def test_post_exec(self, env_mock):
         self.instance._remote.env = env_mock
-        env_out = '''code: 255
+        env_out = """code: 255
 env: A=1^@B=2^@TOKEN=AAAA9B==
 pwd: /some/where
-'''
+"""
 
         code = self.instance.post_exec_command(env_out)
         self.assertEqual(255, code)
 
-    @patch('sshkernel.ssh_wrapper_plumbum.SSHWrapperPlumbum')
+    @patch("sshkernel.ssh_wrapper_plumbum.SSHWrapperPlumbum")
     def test__update_interrupt_function(self, proc):
         fn_before = self.instance.interrupt_function
         self.instance._update_interrupt_function(proc)
@@ -187,7 +210,7 @@ pwd: /some/where
         self.assertTrue(callable(fn_after))
         self.assertNotEqual(fn_before, fn_after)
 
-    @patch('sshkernel.ssh_wrapper_plumbum.SSHWrapperPlumbum')
+    @patch("sshkernel.ssh_wrapper_plumbum.SSHWrapperPlumbum")
     def test__update_interrupt_function_inject_proc_to_closure(self, proc):
         self.instance._update_interrupt_function(proc)
         fn_after = self.instance.interrupt_function
@@ -198,7 +221,6 @@ pwd: /some/where
 
 
 class UtilityTest(unittest.TestCase):
-
     def test_merge_stdout_stderr(self):
         lines = [
             ("a", None),
@@ -219,13 +241,18 @@ class UtilityTest(unittest.TestCase):
             self.assertIsNotNone(line)
 
     def test_process_output_with_newline(self):
-        marker = 'MARKER'
+        marker = "MARKER"
+
         def gen_iterator():
-            lines = io.StringIO('''line1
+            lines = io.StringIO(
+                """line1
 line2
 {marker}code: 0{marker}
 {marker}pwd: /tmp{marker}
-'''.format(marker=marker))
+""".format(
+                    marker=marker
+                )
+            )
             for line in lines:
                 yield (line, None)
 
@@ -233,20 +260,25 @@ line2
         print_function = Mock()
 
         env_info = process_output(iterator, marker, print_function)
-        env_info_expected = 'code: 0\npwd: /tmp\n'
+        env_info_expected = "code: 0\npwd: /tmp\n"
 
         self.assertEqual(env_info, env_info_expected)
-        print_function.assert_any_call('line1\n')
-        print_function.assert_any_call('line2\n')
+        print_function.assert_any_call("line1\n")
+        print_function.assert_any_call("line2\n")
 
     def test_process_output_without_newline(self):
-        marker = 'MARKER'
+        marker = "MARKER"
+
         def gen_iterator():
-            lines = io.StringIO('''line1
+            lines = io.StringIO(
+                """line1
 line2
 line3{marker}code: 0{marker}
 {marker}pwd: /tmp{marker}
-'''.format(marker=marker))
+""".format(
+                    marker=marker
+                )
+            )
             for line in lines:
                 yield (line, None)
 
@@ -254,7 +286,8 @@ line3{marker}code: 0{marker}
         print_function = Mock()
         env_info = process_output(iterator, marker, print_function)
 
-        print_function.assert_any_call('line1\n')
-        print_function.assert_any_call('line2\n')
-        print_function.assert_any_call('line3')  # without newline
-        self.assertEqual(env_info, 'code: 0\npwd: /tmp\n')
+        print_function.assert_any_call("line1\n")
+        print_function.assert_any_call("line2\n")
+        print_function.assert_any_call("line3")  # without newline
+        self.assertEqual(env_info, "code: 0\npwd: /tmp\n")
+

--- a/tests/unit/test_ssh_wrapper_plumbum.py
+++ b/tests/unit/test_ssh_wrapper_plumbum.py
@@ -16,20 +16,23 @@ from sshkernel.ssh_wrapper_plumbum import process_output
 
 class SSHWrapperPlumbumTest(unittest.TestCase):
     def setUp(self):
-        subscriptable = Mock()
-        subscriptable.popen = Mock(return_value=subscriptable)
-        subscriptable.__getitem__ = Mock(return_value=subscriptable)
-        subscriptable.iter_lines = Mock(
-            return_value=([("output", None), (None, "err")])
-        )
+        def new_test_instance():
+            subscriptable = Mock()
+            subscriptable.popen = Mock(return_value=subscriptable)
+            subscriptable.__getitem__ = Mock(return_value=subscriptable)
+            subscriptable.iter_lines = Mock(
+                return_value=([("output", None), (None, "err")])
+            )
 
-        remote_double = Mock(spec=ParamikoMachine)
-        remote_double.__getitem__ = Mock(return_value=subscriptable)
+            remote_double = Mock(spec=ParamikoMachine)
+            remote_double.__getitem__ = Mock(return_value=subscriptable)
 
-        instance = SSHWrapperPlumbum()
-        instance._remote = remote_double
+            instance = SSHWrapperPlumbum()
+            instance._remote = remote_double
 
-        self.instance = instance
+            return instance
+
+        self.instance = new_test_instance()
 
     def test_connect_should_raise_socket_error(self):
         # FIXME: fix setUp() to pass the line below
@@ -55,7 +58,6 @@ class SSHWrapperPlumbumTest(unittest.TestCase):
 
     @unittest.skip("fix setUp")
     def test_exec_command_returns_error_at_first(self):
-        print_mock = Mock()
         with self.assertRaises(socket.gaierror):
             self.instance.exec_command("yo", lambda line: None)
 
@@ -97,9 +99,7 @@ class SSHWrapperPlumbumTest(unittest.TestCase):
 
             f.seek(0)
 
-            (hostname, lookup, forward) = load_ssh_config_for_plumbum(
-                f.name, "test"
-            )
+            (hostname, lookup, forward) = load_ssh_config_for_plumbum(f.name, "test")
 
             self.assertIsInstance(lookup, dict)
             self.assertEqual(hostname, "127.0.0.10")
@@ -117,9 +117,7 @@ class SSHWrapperPlumbumTest(unittest.TestCase):
 
             f.seek(0)
 
-            (hostname, lookup, _) = load_ssh_config_for_plumbum(
-                f.name, "test2"
-            )
+            (hostname, lookup, _) = load_ssh_config_for_plumbum(f.name, "test2")
 
             self.assertIsInstance(lookup, dict)
             self.assertEqual(hostname, "test2")
@@ -142,9 +140,7 @@ class SSHWrapperPlumbumTest(unittest.TestCase):
 
             f.seek(0)
 
-            (hostname, lookup, forward) = load_ssh_config_for_plumbum(
-                f.name, "test3"
-            )
+            (hostname, lookup, forward) = load_ssh_config_for_plumbum(f.name, "test3")
 
             self.assertEqual(set(lookup.keys()), set(["user", "port", "keyfile"]))
 
@@ -282,4 +278,3 @@ line3{marker}code: 0{marker}
         print_function.assert_any_call("line2\n")
         print_function.assert_any_call("line3")  # without newline
         self.assertEqual(env_info, "code: 0\npwd: /tmp\n")
-

--- a/tests/unit/test_ssh_wrapper_plumbum.py
+++ b/tests/unit/test_ssh_wrapper_plumbum.py
@@ -37,7 +37,7 @@ class SSHWrapperPlumbumTest(unittest.TestCase):
     def test_connect_should_raise_socket_error(self):
         # FIXME: fix setUp() to pass the line below
         # self.assertIsNone(self.instance._remote)
-        self.assertFalse(self.instance._connected)
+        self.assertFalse(self.instance.isconnected())
 
         with self.assertRaises(socket.gaierror):
             self.instance.connect("dummy")
@@ -47,12 +47,12 @@ class SSHWrapperPlumbumTest(unittest.TestCase):
         self.instance._build_remote = Mock(return_value=remote_double)
         dummy = "dummy"
         # self.assertIsNone(self.instance._remote)
-        self.assertFalse(self.instance._connected)
+        self.assertFalse(self.instance.isconnected())
         self.assertEqual(self.instance._host, "")
 
         self.instance.connect(dummy)
 
-        self.assertTrue(self.instance._connected)
+        self.assertTrue(self.instance.isconnected())
         self.assertEqual(self.instance._host, dummy)
         remote_double.env.update.assert_called()
 


### PR DESCRIPTION
Closes #17 .

When using ProxyCommand, there is a restriction that HostName cannot be used. 
This behavior is due to the limitations of Plumbum and is not desirable; we might consider eliminating the dependency on Plumbum.

### Examples

OK
```
Host server1.example.org
    ProxyCommand ssh -W %h:%p firewall.example.org    
```

NG
```
Host server2
    HostName server2.example.org
    ProxyCommand ssh -W %h:%p firewall.example.org
```
