### PR TITLE
Use PyYAML yaml.safe_load() instead of yaml.load()

### DIFF
--- a/sshkernel/ssh_wrapper_plumbum.py
+++ b/sshkernel/ssh_wrapper_plumbum.py
@@ -112,7 +112,7 @@ class SSHWrapperPlumbum(SSHWrapper):
         Return:
             int: exit_code
         """
-        env_at_footer = yaml.load(env_out)
+        env_at_footer = yaml.safe_load(env_out)
 
         newdir = env_at_footer["pwd"]
         newenv = env_at_footer["env"]


### PR DESCRIPTION
PyYAML 6.0 `yaml.load()` requires `loader` parameter or raises type error.

See https://msg.pyyaml.org/load